### PR TITLE
Make turn/spawn_enabled persisted attributes on the Game

### DIFF
--- a/lib/battle_box/games/robot_game/game/game.ex
+++ b/lib/battle_box/games/robot_game/game/game.ex
@@ -16,6 +16,7 @@ defmodule BattleBox.Games.RobotGame.Game do
     field :spawn_per_player, :integer, default: 5
     field :robot_hp, :integer, default: 50
     field :turn, :integer, default: 0
+    field :spawn_enabled, :boolean, default: true
     field :max_turns, :integer, default: 100
     field :attack_damage, DamageModifier, default: %{min: 8, max: 10}
     field :collision_damage, DamageModifier, default: 5
@@ -23,7 +24,6 @@ defmodule BattleBox.Games.RobotGame.Game do
     embeds_many :events, Event, on_replace: :delete
 
     field :terrain, :any, default: Terrain.default(), virtual: true
-    field :spawn?, :boolean, default: true, virtual: true
 
     timestamps()
   end
@@ -149,7 +149,7 @@ defmodule BattleBox.Games.RobotGame.Game do
   end
 
   def spawning_round?(game),
-    do: game.spawn? && rem(game.turn, game.spawn_every) == 0
+    do: game.spawn_enabled && rem(game.turn, game.spawn_every) == 0
 
   def get_robot(%__MODULE__{} = game, id), do: get_robot(robots(game), id)
 

--- a/priv/repo/migrations/20191221190556_create_robot_games.exs
+++ b/priv/repo/migrations/20191221190556_create_robot_games.exs
@@ -8,6 +8,7 @@ defmodule BattleBox.Repo.Migrations.CreateRobotGames do
       add :robot_hp, :integer, null: false
       add :events, :jsonb, null: false, default: fragment("'[]'::jsonb")
       add :turn, :integer, null: false
+      add :spawn_enabled, :boolean, null: false, default: true
       add :spawn_every, :integer, null: false
       add :spawn_per_player, :integer, null: false
       add :attack_damage, :jsonb, null: false

--- a/test/battle_box/games/robot_game/game/damage_integrations_test.exs
+++ b/test/battle_box/games/robot_game/game/damage_integrations_test.exs
@@ -12,7 +12,7 @@ defmodule BattleBox.Games.RobotGame.DamageIntegrationTest do
       game:
         Game.new(
           terrain: @terrain,
-          spawn?: false,
+          spawn_enabled: false,
           attack_damage: 1,
           robot_hp: 50,
           suicide_damage: 5

--- a/test/battle_box/games/robot_game/game/game_test.exs
+++ b/test/battle_box/games/robot_game/game/game_test.exs
@@ -137,8 +137,8 @@ defmodule BattleBox.Games.RobotGame.GameTest do
       end)
     end
 
-    test "spawn?: false is never a spawning round" do
-      refute Game.spawning_round?(Game.new(spawn?: false, spawn_every: 10, turn: 10))
+    test "spawn_enabled: false is never a spawning round" do
+      refute Game.spawning_round?(Game.new(spawn_enabled: false, spawn_every: 10, turn: 10))
     end
   end
 

--- a/test/battle_box/games/robot_game/game/move_integrations_test.exs
+++ b/test/battle_box/games/robot_game/game/move_integrations_test.exs
@@ -12,7 +12,7 @@ defmodule BattleBox.Games.RobotGame.Game.MoveIntegrationTest do
                       0 0/
 
     game =
-      Game.new(terrain: terrain, spawn?: false)
+      Game.new(terrain: terrain, spawn_enabled: false)
       |> Game.put_events(robot_spawns)
 
     assert %{location: {0, 0}} =
@@ -84,7 +84,7 @@ defmodule BattleBox.Games.RobotGame.Game.MoveIntegrationTest do
       |> Enum.map(fn effect -> %{move: :test_setup, effects: [effect]} end)
 
     initial_game =
-      Game.new(terrain: terrain, spawn?: false)
+      Game.new(terrain: terrain, spawn_enabled: false)
       |> Game.put_events(robot_spawns)
 
     moves =


### PR DESCRIPTION
Also fixed a bug around how Game.persist was persisting games. Ugh why
is working with embedded schemas so annoying...