### PR TITLE
Fix the issue with trying to find the location of a destroyed robot

### DIFF
--- a/lib/battle_box/games/robot_game/game/logic.ex
+++ b/lib/battle_box/games/robot_game/game/logic.ex
@@ -14,9 +14,12 @@ defmodule BattleBox.Games.RobotGame.Game.Logic do
         do: put_events(game, generate_spawn_events(game)),
         else: game
 
+    post_spawn_robots_ids = Enum.map(robots(game), & &1.id)
+
     movements =
       for move <- moves,
           move["type"] == "move",
+          move["robot_id"] in post_spawn_robots_ids,
           do: move
 
     guard_locations =


### PR DESCRIPTION
This comes from the fact that robots can destroy other robots by
spawning on top of them. If that happens then the move for that robot
becomes illegal