### PR TITLE
Remove `winner`, `player_1`, `player_1` from RGames

### DIFF
--- a/lib/battle_box/game_server/game_server.ex
+++ b/lib/battle_box/game_server/game_server.ex
@@ -137,6 +137,7 @@ defmodule BattleBox.GameServer do
     {:game_over,
      %{
        game_id: Game.id(game),
+       score: Game.score(game),
        winner: Game.winner(game)
      }}
   end

--- a/lib/battle_box/games/game_protocol.ex
+++ b/lib/battle_box/games/game_protocol.ex
@@ -8,9 +8,6 @@ defprotocol BattleBoxGame do
   @spec over?(struct()) :: boolean()
   def over?(game)
 
-  @spec winner(struct()) :: atom
-  def winner(game)
-
   @spec persist(struct()) :: {:ok, struct()}
   def persist(game)
 
@@ -26,4 +23,10 @@ defprotocol BattleBoxGame do
 
   @spec move_time_ms(struct()) :: non_neg_integer()
   def move_time_ms(game)
+
+  @spec score(struct()) :: %{binary => integer()}
+  def score(game)
+
+  @spec winner(struct()) :: binary | nil
+  def winner(game)
 end

--- a/lib/battle_box/match_maker/match_maker_logic.ex
+++ b/lib/battle_box/match_maker/match_maker_logic.ex
@@ -8,11 +8,7 @@ defmodule BattleBox.MatchMaker.MatchMakerLogic do
     |> Enum.map(fn
       [player_1, player_2] ->
         %{
-          game:
-            Game.new(
-              player_1: player_1.player_id,
-              player_2: player_2.player_id
-            ),
+          game: Game.new(),
           players: %{
             "player_1" => player_1.pid,
             "player_2" => player_2.pid

--- a/lib/battle_box_web/templates/robot_game/game_header.html.eex
+++ b/lib/battle_box_web/templates/robot_game/game_header.html.eex
@@ -1,7 +1,8 @@
+<% %{"player_1" => p1_score, "player_2" => p2_score} = Game.score(@game) %>
 <div class="game-header">
   <div class="score player_1">
-    <div class="number"><%= Game.score(@game, "player_1") %></div>
-    <div class="player-name"><%= Game.user(@game, "player_1") %></div>
+    <div class="number"><%= p1_score %></div>
+    <div class="player-name">Player 1</div>
   </div>
 
   <div class="title-section">
@@ -10,7 +11,7 @@
   </div>
 
   <div class="score player_2">
-    <div class="number"><%= Game.score(@game, "player_2") %></div>
-    <div class="player-name"><%= Game.user(@game, "player_2") %></div>
+    <div class="number"><%= p2_score %></div>
+    <div class="player-name">Player 2</div>
   </div>
 </div>

--- a/priv/repo/migrations/20191221190556_create_robot_games.exs
+++ b/priv/repo/migrations/20191221190556_create_robot_games.exs
@@ -3,9 +3,6 @@ defmodule BattleBox.Repo.Migrations.CreateRobotGames do
 
   def change do
     create table("robot_games") do
-      add :player_1, :uuid, null: false
-      add :player_2, :uuid, null: false
-      add :winner, :uuid, null: true
       add :robot_hp, :integer, null: false
       add :events, :jsonb, null: false, default: fragment("'[]'::jsonb")
       add :turn, :integer, null: false
@@ -19,8 +16,5 @@ defmodule BattleBox.Repo.Migrations.CreateRobotGames do
 
       timestamps()
     end
-
-    create index("robot_games", [:player_1])
-    create index("robot_games", [:player_2])
   end
 end

--- a/test/battle_box/game_server/game_server_test.exs
+++ b/test/battle_box/game_server/game_server_test.exs
@@ -4,9 +4,6 @@ defmodule BattleBox.GameServerTest do
   import BattleBox.TestConvenienceHelpers, only: [named_proxy: 1]
   use BattleBox.DataCase
 
-  @player_1 Ecto.UUID.generate()
-  @player_2 Ecto.UUID.generate()
-
   setup %{test: name} do
     {:ok, _} = GameEngine.start_link(name: name)
     {:ok, GameEngine.names(name)}
@@ -19,7 +16,7 @@ defmodule BattleBox.GameServerTest do
           "player_1" => named_proxy(:player_1),
           "player_2" => named_proxy(:player_2)
         },
-        game: Game.new(player_1: @player_1, player_2: @player_2)
+        game: Game.new()
       }
     }
   end
@@ -135,8 +132,8 @@ defmodule BattleBox.GameServerTest do
     :ok = GameServer.accept_game(pid, "player_2")
     :ok = GameServer.forfeit_game(pid, "player_1")
 
-    assert_receive {:player_1, {:game_over, %{winner: @player_2}}}
-    assert_receive {:player_2, {:game_over, %{winner: @player_2}}}
+    assert_receive {:player_1, {:game_over, %{winner: "player_2"}}}
+    assert_receive {:player_2, {:game_over, %{winner: "player_2"}}}
   end
 
   test "if you die its the same as a forefit", context do
@@ -151,11 +148,11 @@ defmodule BattleBox.GameServerTest do
     Process.exit(player_2_pid, :kill)
     assert_receive {:EXIT, ^player_2_pid, :killed}
 
-    assert_receive {:player_1, {:game_over, %{winner: @player_1}}}
+    assert_receive {:player_1, {:game_over, %{winner: "player_1"}}}
   end
 
   test "you can play a game! (and it persists it to the db when you're done)", context do
-    game = Game.new(player_1: @player_1, player_2: @player_2, max_turns: 10)
+    game = Game.new(max_turns: 10)
 
     {:ok, pid} = GameEngine.start_game(context.game_engine, %{context.init_opts | game: game})
 

--- a/test/battle_box/games/robot_game/game/event_test.exs
+++ b/test/battle_box/games/robot_game/game/event_test.exs
@@ -4,7 +4,6 @@ defmodule BattleBox.Games.RobotGame.Game.EventTest do
   import Ecto.Query, only: [from: 2]
 
   @robot_id "7b875c94-8fe0-4fa3-992a-d6d9f7da1a08"
-  @player_id "7b875c94-8fe0-4fa3-992a-d6d9f7da1a08"
 
   @move_move %{"type" => "move", "robot_id" => @robot_id, "target" => [0, 0]}
   @guard_move %{"type" => "guard", "robot_id" => @robot_id}
@@ -58,8 +57,7 @@ defmodule BattleBox.Games.RobotGame.Game.EventTest do
       }
     ]
     |> Enum.each(fn event ->
-      game =
-        Game.new(player_1: @player_id, player_2: @player_id, events: [event]) |> Game.changeset()
+      game = Game.new(events: [event]) |> Game.changeset()
 
       {:ok, game} = Repo.insert(game)
 

--- a/test/battle_box/match_maker/match_maker_logic_test.exs
+++ b/test/battle_box/match_maker/match_maker_logic_test.exs
@@ -32,9 +32,6 @@ defmodule BattleBox.MatchMaker.MatchMakerLogicTest do
 
     assert [%{game: game, players: %{"player_1" => ^player_1_pid, "player_2" => ^player_2_pid}}] =
              matches
-
-    assert game.player_1 == @player_1_id
-    assert game.player_2 == @player_2_id
   end
 
   test "it will only make one match if there are three in the queue" do
@@ -54,8 +51,5 @@ defmodule BattleBox.MatchMaker.MatchMakerLogicTest do
 
     assert [%{game: game, players: %{"player_1" => ^player_1_pid, "player_2" => ^player_2_pid}}] =
              matches
-
-    assert game.player_1 == @player_1_id
-    assert game.player_2 == @player_2_id
   end
 end

--- a/test/battle_box_web/live/game_live_test.exs
+++ b/test/battle_box_web/live/game_live_test.exs
@@ -4,21 +4,12 @@ defmodule BattleBoxWeb.GameLiveTest do
   alias BattleBox.{GameEngine, GameServer, Games.RobotGame.Game}
   import BattleBox.TestConvenienceHelpers, only: [named_proxy: 1]
 
-  @player_1 Ecto.UUID.generate()
-  @player_2 Ecto.UUID.generate()
   @game_id Ecto.UUID.generate()
 
   test "it can display a game off disk", %{conn: conn} do
     id = Ecto.UUID.generate()
 
-    {:ok, _} =
-      Game.persist(
-        Game.new(%{
-          player_1: @player_1,
-          player_2: @player_2,
-          id: id
-        })
-      )
+    {:ok, _} = Game.persist(Game.new(%{id: id}))
 
     {:ok, _view, html} = live(conn, "/games/#{id}")
     assert html =~ "TURN: 0 / 100"
@@ -42,7 +33,7 @@ defmodule BattleBoxWeb.GameLiveTest do
             "player_1" => named_proxy(:player_1),
             "player_2" => named_proxy(:player_2)
           },
-          game: Game.new(player_1: @player_1, player_2: @player_2, id: @game_id)
+          game: Game.new(id: @game_id)
         })
 
       :ok = GameServer.accept_game(pid, "player_1")

--- a/test/battle_box_web/live/games_live_live_test.exs
+++ b/test/battle_box_web/live/games_live_live_test.exs
@@ -4,8 +4,6 @@ defmodule BattleBoxWeb.GamesLiveLiveTest do
   alias BattleBox.{GameEngine, GameServer, Games.RobotGame.Game}
   import BattleBox.TestConvenienceHelpers, only: [named_proxy: 1]
 
-  @player_1 Ecto.UUID.generate()
-  @player_2 Ecto.UUID.generate()
   @game_id Ecto.UUID.generate()
 
   test "it renders", %{conn: conn} do
@@ -29,7 +27,7 @@ defmodule BattleBoxWeb.GamesLiveLiveTest do
             "player_1" => named_proxy(:player_1),
             "player_2" => named_proxy(:player_2)
           },
-          game: Game.new(player_1: @player_1, player_2: @player_2, id: @game_id)
+          game: Game.new(id: @game_id)
         })
 
       :ok = GameServer.accept_game(pid, "player_1")


### PR DESCRIPTION
We really don't want to keep this data on the robot game table, we need
a more general battle box games table to store cross game stats for a
bot