### PR TITLE
Store robots per turn in memory

### DIFF
--- a/test/battle_box/games/robot_game/game/damage_integrations_test.exs
+++ b/test/battle_box/games/robot_game/game/damage_integrations_test.exs
@@ -30,7 +30,7 @@ defmodule BattleBox.Games.RobotGame.DamageIntegrationTest do
         settings: %{terrain: @terrain, spawn_enabled: false, attack_damage: 50, robot_hp: 50}
       )
 
-    inital_game = Game.put_events(game, robot_spawns)
+    inital_game = Game.put_events(game, robot_spawns) |> Game.complete_turn()
     player_2_moves = [%{"type" => "attack", "target" => [0, 0], "robot_id" => 2}]
 
     after_turn =
@@ -50,7 +50,7 @@ defmodule BattleBox.Games.RobotGame.DamageIntegrationTest do
       %{"type" => "attack", "target" => [0, 0], "robot_id" => 2}
     ]
 
-    inital_game = Game.put_events(game, robot_spawns)
+    inital_game = Game.put_events(game, robot_spawns) |> Game.complete_turn()
 
     after_turn =
       Logic.calculate_turn(inital_game, %{
@@ -75,7 +75,7 @@ defmodule BattleBox.Games.RobotGame.DamageIntegrationTest do
       %{"type" => "attack", "target" => [0, 0], "robot_id" => 2}
     ]
 
-    inital_game = Game.put_events(game, robot_spawns)
+    inital_game = Game.put_events(game, robot_spawns) |> Game.complete_turn()
 
     after_turn =
       Logic.calculate_turn(inital_game, %{
@@ -101,7 +101,7 @@ defmodule BattleBox.Games.RobotGame.DamageIntegrationTest do
       %{"type" => "move", "target" => [1, 0], "robot_id" => 2}
     ]
 
-    inital_game = Game.put_events(game, robot_spawns)
+    inital_game = Game.put_events(game, robot_spawns) |> Game.complete_turn()
 
     after_turn =
       Logic.calculate_turn(inital_game, %{
@@ -124,7 +124,7 @@ defmodule BattleBox.Games.RobotGame.DamageIntegrationTest do
       %{"type" => "attack", "target" => [0, 0], "robot_id" => 4}
     ]
 
-    inital_game = Game.put_events(game, robot_spawns)
+    inital_game = Game.put_events(game, robot_spawns) |> Game.complete_turn()
 
     after_turn =
       Logic.calculate_turn(inital_game, %{"player_1" => [], "player_2" => player_2_moves})
@@ -140,7 +140,7 @@ defmodule BattleBox.Games.RobotGame.DamageIntegrationTest do
       %{"type" => "attack", "target" => [0, 0], "robot_id" => 2}
     ]
 
-    inital_game = Game.put_events(game, robot_spawns)
+    inital_game = Game.put_events(game, robot_spawns) |> Game.complete_turn()
 
     after_turn =
       Logic.calculate_turn(inital_game, %{"player_1" => [], "player_2" => player_2_moves})
@@ -155,7 +155,7 @@ defmodule BattleBox.Games.RobotGame.DamageIntegrationTest do
       %{"type" => "attack", "target" => [0, 0], "robot_id" => 1}
     ]
 
-    inital_game = Game.put_events(game, robot_spawns)
+    inital_game = Game.put_events(game, robot_spawns) |> Game.complete_turn()
 
     after_turn =
       Logic.calculate_turn(inital_game, %{"player_1" => player_1_moves, "player_2" => []})
@@ -171,7 +171,7 @@ defmodule BattleBox.Games.RobotGame.DamageIntegrationTest do
       %{"type" => "suicide", "robot_id" => 1}
     ]
 
-    inital_game = Game.put_events(game, robot_spawns)
+    inital_game = Game.put_events(game, robot_spawns) |> Game.complete_turn()
 
     after_turn =
       Logic.calculate_turn(inital_game, %{"player_1" => player_1_moves, "player_2" => []})

--- a/test/battle_box/games/robot_game/game/game_test.exs
+++ b/test/battle_box/games/robot_game/game/game_test.exs
@@ -150,11 +150,11 @@ defmodule BattleBox.Games.RobotGame.GameTest do
     end
 
     test "you can persist changes multiple time" do
-      game = Game.new(turn: 42, settings: %{terrain: %{}})
+      game = Game.new(settings: %{terrain: %{}})
       assert {:ok, game} = Game.persist(game)
       game = Game.complete_turn(game)
       {:ok, game} = Game.persist(game)
-      assert 43 == Game.get_by_id(game.id).turn
+      assert 1 == Game.get_by_id(game.id).turn
     end
 
     test "when you persist a game it flushes the unpersisted events to disk" do
@@ -443,7 +443,7 @@ defmodule BattleBox.Games.RobotGame.GameTest do
       robot_spawns = ~g/121/
 
       game =
-        Game.new(turn: 20, settings: %{max_turns: 20})
+        Game.new(settings: %{max_turns: 0})
         |> Game.put_events(robot_spawns)
 
       assert Game.over?(game)
@@ -454,7 +454,7 @@ defmodule BattleBox.Games.RobotGame.GameTest do
       robot_spawns = ~g/1212/
 
       game =
-        Game.new(turn: 20, settings: %{max_turns: 20})
+        Game.new(settings: %{max_turns: 0})
         |> Game.put_events(robot_spawns)
 
       assert Game.over?(game)

--- a/test/battle_box/games/robot_game/game/move_integrations_test.exs
+++ b/test/battle_box/games/robot_game/game/move_integrations_test.exs
@@ -89,6 +89,7 @@ defmodule BattleBox.Games.RobotGame.Game.MoveIntegrationTest do
     initial_game =
       Game.new(settings: %{terrain: terrain, spawn_enabled: false})
       |> Game.put_events(robot_spawns)
+      |> Game.complete_turn()
 
     moves =
       graph_with_indexes

--- a/test/battle_box_web/views/robot_game_view_test.exs
+++ b/test/battle_box_web/views/robot_game_view_test.exs
@@ -104,8 +104,8 @@ defmodule BattleBoxWeb.RobotGameViewTest do
     end
 
     test "it displays the correct turn" do
-      game = Game.new(turn: 42, settings: %{max_turns: 420})
-      assert render_to_string(RobotGameView, "game_header.html", game: game) =~ "TURN: 42 / 420"
+      game = Game.new(settings: %{max_turns: 420}) |> Game.complete_turn() |> Game.complete_turn()
+      assert render_to_string(RobotGameView, "game_header.html", game: game) =~ "TURN: 2 / 420"
     end
 
     test "it displays the correct score" do

--- a/test/support/robot_game_helper.ex
+++ b/test/support/robot_game_helper.ex
@@ -19,7 +19,7 @@ defmodule BattleBox.Games.RobotGameTest.Helpers do
 
       player_id = if rem(val, 2) == 1, do: "player_1", else: "player_2"
 
-      %{move: "test_helper", effects: [["create_robot", player_id, val, 50, location]]}
+      %{cause: "test_helper", effects: [["create_robot", player_id, val, 50, location]]}
     end)
   end
 end


### PR DESCRIPTION
This is a pretty massive optimization, because `Game.robots` gets called
a ton and this makes it significantly easier to calculate that.

Games are 10x faster on my local machine!!!!