### PR TITLE
Garbage collect the game server

### DIFF
--- a/lib/battle_box/game_engine/game_server/game_server.ex
+++ b/lib/battle_box/game_engine/game_server/game_server.ex
@@ -80,7 +80,12 @@ defmodule BattleBox.GameEngine.GameServer do
 
     moves = Map.new(requests, fn {player, _} -> {player, nil} end)
 
-    {:keep_state, Map.put(data, :moves, moves)}
+    {:keep_state, Map.put(data, :moves, moves), {:next_event, :internal, :gc}}
+  end
+
+  def handle_event(:internal, :gc, _, data) do
+    :erlang.garbage_collect()
+    :keep_state_and_data
   end
 
   def handle_event(:cast, {:moves, player, moves}, :moves, data) do


### PR DESCRIPTION
Right now the game server can go from 1mb to 4mbs at max.

If we garbage collect the game server after sending out a request for moves we can lower if down to <1mb and actually around 500kb.

It probably won't affect latency because we know that there isn't anything to do until the moves come back, but it will cost cpu