### PR TITLE
Bot Tokens => User Tokens

### DIFF
--- a/assets/css/settings.css
+++ b/assets/css/settings.css
@@ -54,3 +54,68 @@ a.btn {
   background-position: -.5em;
   border-color: rgba(27,31,35,.5);
 }
+
+.btn-danger {
+  color: #cb2431;
+  background-color: #fafbfc;
+  background-image: linear-gradient(-180deg,#fafbfc,#eff3f6 90%);
+}
+
+.btn-danger:hover {
+  color: #fff;
+  background-color: #cb2431;
+  background-image: linear-gradient(-180deg,#de4450,#cb2431 90%);
+  border-color: rgba(27,31,35,.5);
+}
+
+.form-group {
+  margin: 15px 0;
+}
+
+.form-control, .form-select {
+  min-height: 34px;
+  padding: 6px 8px;
+  font-size: 16px;
+  line-height: 20px;
+  color: #24292e;
+  vertical-align: middle;
+  background-color: #fff;
+  background-repeat: no-repeat;
+  background-position: right 8px center;
+  border: 1px solid #d1d5da;
+  border-radius: 3px;
+  outline: none;
+  box-shadow: inset 0 1px 2px rgba(27,31,35,.075);
+}
+
+.form-group .form-control {
+  width: 440px;
+  max-width: 100%;
+  margin-right: 5px;
+  background-color: #fafbfc;
+}
+
+.form-control:focus, .form-select:focus {
+  border-color: #2188ff;
+  outline: none;
+  box-shadow: inset 0 1px 2px rgba(27,31,35,.075), 0 0 0 0.2em rgba(3,102,214,.3);
+}
+
+.box {
+  background-color: #fff;
+  border: 1px solid #d1d5da;
+  border-radius: 3px;
+}
+
+.box-row {
+  display: flex;
+  align-items: center;
+  padding: 16px;
+  list-style-type: none;
+  border-top: 1px solid #e1e4e8;
+  border-bottom: 1px solid #e1e4e8;
+}
+
+.box-details {
+  margin-right: auto;
+}

--- a/assets/css/settings.css
+++ b/assets/css/settings.css
@@ -1,0 +1,56 @@
+.page-content {
+  padding-top: 40px;
+}
+
+.container {
+  width: 75%;
+  margin-right: auto;
+  margin-left: auto;
+}
+
+.subhead {
+  display: flex;
+  padding-bottom: 8px;
+  margin-bottom: 16px;
+  border-bottom: 1px solid #e1e4e8;
+  flex-flow: row wrap;
+  align-items: center;
+}
+
+.subhead-heading {
+  font-size: 24px;
+  font-weight: 400;
+  flex: 1 1 auto;
+}
+
+a.btn {
+  text-decoration: none;
+}
+
+.btn {
+   display: inline-block;
+   padding: 6px 12px;
+   font-size: 14px;
+   font-weight: 600;
+   line-height: 20px;
+   white-space: nowrap;
+   vertical-align: middle;
+   cursor: pointer;
+   user-select: none;
+   background-repeat: repeat-x;
+   background-position: -1px -1px;
+   background-size: 110% 110%;
+   border: 1px solid rgba(27,31,35,.2);
+   border-radius: .25em;
+}
+
+.btn-primary {
+  color: white;
+  background-image: linear-gradient(-180deg, var(--primary-one), var(--primary-three) 90%);
+}
+
+.btn-primary:hover {
+  background-image: linear-gradient(-180deg, var(--primary-four), var(--primary-three) 90%);
+  background-position: -.5em;
+  border-color: rgba(27,31,35,.5);
+}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -6,6 +6,7 @@ import game_css from "../css/game.css"
 import not_found_css from "../css/not_found.css"
 import bot_follow_css from "../css/bot_follow.css"
 import admin_css from "../css/admin.css"
+import settings_css from "../css/settings.css"
 
 import "phoenix_html"
 import {Socket} from "phoenix"

--- a/lib/battle_box/api_keys/api_key.ex
+++ b/lib/battle_box/api_keys/api_key.ex
@@ -1,0 +1,55 @@
+defmodule BattleBox.ApiKey do
+  alias BattleBox.{Repo, User}
+  import Ecto.Changeset
+  use Ecto.Schema
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+
+  @derive {Inspect, except: [:hashed_token]}
+  schema "api_keys" do
+    field :name, :binary
+    field :token, :string, virtual: true
+    field :hashed_token, :binary
+    field :last_used, :naive_datetime, autogenerate: {__MODULE__, :now, []}
+    belongs_to :user, User
+    timestamps()
+  end
+
+  def changeset(api_key, params) do
+    token = gen_token()
+
+    api_key
+    |> cast(params, [:name])
+    |> validate_length(:name, min: 3, max: 30)
+    |> put_change(:token, token)
+    |> put_change(:hashed_token, hash(token))
+  end
+
+  def from_token(token) do
+    Repo.get_by(__MODULE__, hashed_token: hash(token))
+  end
+
+  def mark_used!(%__MODULE__{} = api_key) do
+    api_key
+    |> change(last_used: now())
+    |> Repo.update!()
+  end
+
+  def gen_token do
+    :crypto.strong_rand_bytes(16)
+    |> Base.encode32(padding: false, case: :lower)
+  end
+
+  defp hash(token) do
+    # Normally when you hash passwords you want to use a much stronger/slower
+    # hash function like argon2. Since API keys are 128 bits of strong random
+    # bytes and not a short user generated phrase, we're safe to use a much faster
+    # hash function. There's a 0% chance of brute forcing 128 random bits
+    :crypto.hash(:sha256, token)
+  end
+
+  def now do
+    NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+  end
+end

--- a/lib/battle_box/api_keys/api_key.ex
+++ b/lib/battle_box/api_keys/api_key.ex
@@ -47,7 +47,7 @@ defmodule BattleBox.ApiKey do
     end
   end
 
-  defp from_token(token) do
+  def from_token(token) do
     Repo.get_by(__MODULE__, hashed_token: hash(token))
   end
 

--- a/lib/battle_box/api_keys/api_key.ex
+++ b/lib/battle_box/api_keys/api_key.ex
@@ -11,7 +11,7 @@ defmodule BattleBox.ApiKey do
     field :name, :binary
     field :token, :string, virtual: true
     field :hashed_token, :binary
-    field :last_used, :naive_datetime, autogenerate: {__MODULE__, :now, []}
+    field :last_used, :naive_datetime
     belongs_to :user, User
     timestamps()
   end
@@ -21,7 +21,8 @@ defmodule BattleBox.ApiKey do
 
     api_key
     |> cast(params, [:name])
-    |> validate_length(:name, min: 3, max: 30)
+    |> validate_required(:name)
+    |> validate_length(:name, max: 30)
     |> put_change(:token, token)
     |> put_change(:hashed_token, hash(token))
   end

--- a/lib/battle_box/api_keys/api_key.ex
+++ b/lib/battle_box/api_keys/api_key.ex
@@ -33,7 +33,7 @@ defmodule BattleBox.ApiKey do
   def mark_used!(%__MODULE__{} = api_key) do
     api_key
     |> change(last_used: now())
-    |> Repo.update!()
+    |> Repo.update()
   end
 
   def gen_token do

--- a/lib/battle_box/bots/bot.ex
+++ b/lib/battle_box/bots/bot.ex
@@ -2,71 +2,25 @@ defmodule BattleBox.Bot do
   alias BattleBox.{User, Game}
   use Ecto.Schema
   import Ecto.Changeset
-  import Ecto.Query, only: [from: 2]
   alias BattleBox.Repo
 
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
 
-  @params [
-    :name,
-    :user_id
-  ]
-
   schema "bots" do
     field :name, :string
-    field :token, :string, autogenerate: {__MODULE__, :generate_token, []}
     many_to_many :games, Game, join_through: "game_bots"
     belongs_to :user, User
-
     timestamps()
   end
 
   def changeset(bot, params \\ %{}) do
     bot
-    |> cast(params, @params)
-    |> validate_required(@params)
-    |> validate_length(:name, min: 3, max: 20)
+    |> cast(params, [:name])
+    |> validate_required(:name)
+    |> validate_length(:name, max: 20)
     |> unique_constraint(:name)
-    |> unique_constraint(:token)
   end
-
-  def create(params) do
-    changeset(%__MODULE__{}, params)
-    |> Repo.insert()
-  end
-
-  def with_user_id(query \\ nil, user_id) do
-    query = query || base()
-    from bot in query, where: bot.user_id == ^user_id
-  end
-
-  def get_by_token(token) do
-    Repo.get_by(__MODULE__, token: token)
-  end
-
-  def banned?(bot) do
-    bot = Repo.preload(bot, :user)
-
-    case bot.user do
-      %User{is_banned: true} -> true
-      _ -> false
-    end
-  end
-
-  def generate_token() do
-    :crypto.strong_rand_bytes(20)
-    |> Base.encode32()
-    |> String.downcase()
-  end
-
-  defp base do
-    from bot in __MODULE__, as: :bot
-  end
-
-  def get_by_identifier(nil), do: nil
-  def get_by_identifier(<<_::288>> = uuid), do: get_by_id(uuid)
-  def get_by_identifier(name), do: get_by_name(name)
 
   def get_by_name(name) do
     Repo.get_by(__MODULE__, name: name)

--- a/lib/battle_box/bots/bot.ex
+++ b/lib/battle_box/bots/bot.ex
@@ -25,8 +25,4 @@ defmodule BattleBox.Bot do
   def get_by_name(name) do
     Repo.get_by(__MODULE__, name: name)
   end
-
-  def get_by_id(id) do
-    Repo.get_by(__MODULE__, id: id)
-  end
 end

--- a/lib/battle_box/connection/logic.ex
+++ b/lib/battle_box/connection/logic.ex
@@ -36,10 +36,11 @@ defmodule BattleBox.Connection.Logic do
     {data, [{:send, encode_error("bot_instance_failure")}], :stop}
   end
 
-  def handle_client(bot_token_auth(token, lobby_name), %{state: :unauthed} = data) do
+  def handle_client(bot_token_auth(token, bot_name, lobby_name), %{state: :unauthed} = data) do
     case GameEngine.start_bot(data.names.game_engine, %{
            token: token,
            lobby_name: lobby_name,
+           bot_name: bot_name,
            connection: self()
          }) do
       {:ok, bot_server, %{user_id: _, bot_server_id: _} = bot_server_info} ->

--- a/lib/battle_box/connection/message.ex
+++ b/lib/battle_box/connection/message.ex
@@ -30,9 +30,9 @@ defmodule BattleBox.Connection.Message do
     encode(error)
   end
 
-  defmacro bot_token_auth(token, lobby_name) do
+  defmacro bot_token_auth(token, bot_name, lobby_name) do
     quote do
-      %{"token" => unquote(token), "lobby" => unquote(lobby_name)}
+      %{"token" => unquote(token), "bot" => unquote(bot_name), "lobby" => unquote(lobby_name)}
     end
   end
 

--- a/lib/battle_box/users/user.ex
+++ b/lib/battle_box/users/user.ex
@@ -1,6 +1,6 @@
 defmodule BattleBox.User do
   use Ecto.Schema
-  alias BattleBox.{Repo, Bot}
+  alias BattleBox.{Repo, Bot, ApiKey}
   import Ecto.Changeset
 
   @primary_key {:id, :binary_id, autogenerate: true}
@@ -21,6 +21,7 @@ defmodule BattleBox.User do
     field :is_admin, :boolean, default: false
     field :is_banned, :boolean, default: false
     has_many :bots, Bot
+    has_many :api_keys, ApiKey
 
     timestamps()
   end

--- a/lib/battle_box_web/controllers/api_key_controller.ex
+++ b/lib/battle_box_web/controllers/api_key_controller.ex
@@ -1,0 +1,9 @@
+defmodule BattleBoxWeb.ApiKeyController do
+  use BattleBoxWeb, :controller
+  alias BattleBox.{Repo, ApiKey}
+
+  def index(%{assigns: %{user: user}} = conn, _params) do
+    user = Repo.preload(user, :api_keys)
+    render(conn, "index.html", user: user)
+  end
+end

--- a/lib/battle_box_web/controllers/api_key_controller.ex
+++ b/lib/battle_box_web/controllers/api_key_controller.ex
@@ -8,7 +8,9 @@ defmodule BattleBoxWeb.ApiKeyController do
   end
 
   def delete(%{assigns: %{user: user}} = conn, %{"id" => id}) do
-    api_key = Repo.one(from api_key in ApiKey, where: api_key.user_id == ^user.id and api_key.id == ^id)
+    api_key =
+      Repo.one(from api_key in ApiKey, where: api_key.user_id == ^user.id and api_key.id == ^id)
+
     {:ok, _key} = Repo.delete(api_key)
     redirect(conn, to: Routes.api_key_path(conn, :index))
   end

--- a/lib/battle_box_web/controllers/api_key_controller.ex
+++ b/lib/battle_box_web/controllers/api_key_controller.ex
@@ -1,6 +1,27 @@
 defmodule BattleBoxWeb.ApiKeyController do
   use BattleBoxWeb, :controller
   alias BattleBox.{Repo, ApiKey}
+  import Ecto.Query, only: [from: 2]
+
+  def new(conn, _params) do
+    render(conn, "new.html")
+  end
+
+  def delete(%{assigns: %{user: user}} = conn, %{"id" => id}) do
+    api_key = Repo.one(from api_key in ApiKey, where: api_key.user_id == ^user.id and api_key.id == ^id)
+    {:ok, _key} = Repo.delete(api_key)
+    redirect(conn, to: Routes.api_key_path(conn, :index))
+  end
+
+  def create(%{assigns: %{user: user}} = conn, %{"api_key" => params}) do
+    {:ok, api_key} =
+      user
+      |> Ecto.build_assoc(:api_keys)
+      |> ApiKey.changeset(params)
+      |> Repo.insert()
+
+    render(conn, "show.html", api_key: api_key)
+  end
 
   def index(%{assigns: %{user: user}} = conn, _params) do
     user = Repo.preload(user, :api_keys)

--- a/lib/battle_box_web/controllers/bot_controller.ex
+++ b/lib/battle_box_web/controllers/bot_controller.ex
@@ -19,7 +19,7 @@ defmodule BattleBoxWeb.BotController do
       {:ok, bot} ->
         conn
         |> put_flash(:info, "Bot created")
-        |> redirect(to: Routes.live_path(conn, :show, bot.name))
+        |> redirect(to: Routes.bot_path(conn, :show, bot.name))
 
       {:error, changeset} ->
         render(conn, "new.html", changeset: changeset)

--- a/lib/battle_box_web/controllers/bot_controller.ex
+++ b/lib/battle_box_web/controllers/bot_controller.ex
@@ -1,29 +1,37 @@
 defmodule BattleBoxWeb.BotController do
   use BattleBoxWeb, :controller
   alias BattleBoxWeb.PageView
-  alias BattleBox.Bot
+  alias BattleBox.{Repo, Bot}
 
   def new(conn, _params) do
     changeset = Bot.changeset(%Bot{})
     render(conn, "new.html", changeset: changeset)
   end
 
-  def create(%{assigns: %{user: user}} = conn, %{"bot" => bot}) do
-    params = Map.put(bot, "user_id", user.id)
+  def create(%{assigns: %{user: user}} = conn, %{"bot" => params}) do
+    result =
+      user
+      |> Ecto.build_assoc(:bots)
+      |> Bot.changeset(params)
+      |> Repo.insert()
 
-    case Bot.create(params) do
+    case result do
       {:ok, bot} ->
         conn
-        |> put_flash(:info, "Bot created successfully.")
-        |> redirect(to: Routes.bot_path(conn, :show, bot.id))
+        |> put_flash(:info, "Bot created")
+        |> redirect(to: Routes.live_path(conn, :show, bot.name))
 
       {:error, changeset} ->
         render(conn, "new.html", changeset: changeset)
     end
   end
 
-  def show(conn, %{"id" => id}) do
-    case Bot.get_by_identifier(id) do
+  def show(conn, %{"id" => name}) do
+    bot =
+      Bot.get_by_name(name)
+      |> Repo.preload(:user)
+
+    case bot do
       %Bot{} = bot ->
         render(conn, "show.html", bot: bot)
 

--- a/lib/battle_box_web/router.ex
+++ b/lib/battle_box_web/router.ex
@@ -49,10 +49,11 @@ defmodule BattleBoxWeb.Router do
       pipe_through :require_logged_in
       pipe_through :require_not_banned
 
-      get "/lobbies", UserRedirectController, :lobbies
-      get "/bots", UserRedirectController, :bots
       get "/me", UserRedirectController, :users
+      get "/bots", UserRedirectController, :bots
+      get "/lobbies", UserRedirectController, :lobbies
 
+      resources "/keys", ApiKeyController
       resources "/bots", BotController, only: [:create, :new]
       resources "/lobbies", LobbyController, only: [:create, :new]
     end

--- a/lib/battle_box_web/templates/api_key/index.html.eex
+++ b/lib/battle_box_web/templates/api_key/index.html.eex
@@ -1,0 +1,8 @@
+<div class="page-content container">
+  <div class="subhead">
+    <div class="subhead-heading">API Keys</div>
+    <div class="subhead-action">
+      <a class="btn btn-primary">New API Key</a>
+    </div>
+  </div>
+</div>

--- a/lib/battle_box_web/templates/api_key/index.html.eex
+++ b/lib/battle_box_web/templates/api_key/index.html.eex
@@ -2,7 +2,24 @@
   <div class="subhead">
     <div class="subhead-heading">API Keys</div>
     <div class="subhead-action">
-      <a class="btn btn-primary">New API Key</a>
+      <a href="<%= Routes.api_key_path(@conn, :new) %>" class="btn btn-primary">New API Key</a>
     </div>
+  </div>
+  <p>API Keys for accessing Botskrieg</p>
+  <div class="box">
+    <%= for api_key <- @user.api_keys do %>
+      <div class="box-row">
+        <div class="box-details">
+          <div style="font-weight: bolder; padding-bottom: 10px;">Name: <%= api_key.name %></div>
+          <div>Created: <%= humanize_seconds_ago(api_key.inserted_at) %></div>
+          <div>Last Used: <%= if api_key.last_used, do: humanize_seconds_ago(api_key.last_used), else: "Never" %></div>
+        </div>
+        <form action="/keys/<%= api_key.id %>" method="post">
+          <input name="_csrf_token" type="hidden" value="<%= Plug.CSRFProtection.get_csrf_token() %>">
+          <input type="hidden" name="_method" value="delete">
+          <button type="submit" class="btn btn-danger btn-block mt-3">Revoke</button>
+        </form>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/lib/battle_box_web/templates/api_key/new.html.eex
+++ b/lib/battle_box_web/templates/api_key/new.html.eex
@@ -10,7 +10,7 @@
     <input name="_csrf_token" type="hidden" value="<%= Plug.CSRFProtection.get_csrf_token() %>">
 
     <div class="form-group">
-      <label for="api_key_title">Name:</label>
+      <label for="api_key_name">Name:</label>
       <input maxlength="30" required class="form-control" type="text" name="api_key[name]" id="api_key_title">
     </div>
 

--- a/lib/battle_box_web/templates/api_key/new.html.eex
+++ b/lib/battle_box_web/templates/api_key/new.html.eex
@@ -1,0 +1,19 @@
+<div class="page-content container">
+  <div class="subhead">
+    <div class="subhead-heading">
+      <a href="<%= Routes.api_key_path(@conn, :index) %>">API Keys</a>
+      / Create
+    </div>
+  </div>
+
+  <form class="new_public_key" id="new_key" action="/keys" method="post">
+    <input name="_csrf_token" type="hidden" value="<%= Plug.CSRFProtection.get_csrf_token() %>">
+
+    <div class="form-group">
+      <label for="api_key_title">Name:</label>
+      <input maxlength="30" required class="form-control" type="text" name="api_key[name]" id="api_key_title">
+    </div>
+
+    <button type="submit" class="btn btn-primary">Create API Key</button>
+  </form>
+</div>

--- a/lib/battle_box_web/templates/api_key/show.html.eex
+++ b/lib/battle_box_web/templates/api_key/show.html.eex
@@ -1,0 +1,10 @@
+<div class="page-content container">
+  <div class="subhead">
+    <div class="subhead-heading">
+      <a href="<%= Routes.api_key_path(@conn, :index) %>">API Keys</a>
+      / <%= @api_key.name %>
+    </div>
+  </div>
+  <p>Record this token, it won't be available again!<p>
+  <div style="font-size: 3em;"><%= @api_key.token %></div>
+</div>

--- a/lib/battle_box_web/templates/bot/bots.html.leex
+++ b/lib/battle_box_web/templates/bot/bots.html.leex
@@ -3,7 +3,7 @@
 <h1>User: <%= @user.github_login_name %></h1>
 <a href="<%= Routes.bot_path(BattleBoxWeb.Endpoint, :new) %>">New Bot</a>
 <div class="bots">
-  <%= for bot <- @bots do %>
+  <%= for bot <- @user.bots do %>
     <div class="bot">
       <div>Name: <a href="<%= Routes.bot_path(BattleBoxWeb.Endpoint, :show, bot.name) %>"><%= bot.name %></a></div>
       <div class="bot-servers">

--- a/lib/battle_box_web/templates/bot/new.html.eex
+++ b/lib/battle_box_web/templates/bot/new.html.eex
@@ -1,6 +1,16 @@
-<h1>Create a bot</h1>
-<%= form_for @changeset, Routes.bot_path(@conn, :create), fn f -> %>
-  <label>Name: <%= text_input f, :name %></label><br>
-  <%= error_tag f, :name %>
-  <%= submit "Submit" %>
-<% end %>
+<div class="page-content container">
+  <div class="subhead">
+    <div class="subhead-heading">
+      <a href="<%= Routes.live_path(@conn, BattleBoxWeb.Bots, @user.id) %>">Bots</a>
+      / Create
+    </div>
+  </div>
+  <%= form_for @changeset, Routes.bot_path(@conn, :create), fn f -> %>
+    <div class="form-group">
+      <label>Name: <%= text_input f, :name, class: "form-control" %></label><br>
+      <%= error_tag f, :name %>
+    </div>
+
+    <%= submit "Create Bot", class: "btn btn-primary" %>
+  <% end %>
+</div>

--- a/lib/battle_box_web/templates/bot/show.html.eex
+++ b/lib/battle_box_web/templates/bot/show.html.eex
@@ -1,5 +1,8 @@
-<div>
-  <div>Name: <%= @bot.name %></div>
-  <div>Token: <code><%= @bot.token %></code></div>
-  <div>User: <%= @bot.user_id %></div>
+<div class="page-content container">
+  <div class="subhead">
+    <div class="subhead-heading">
+      <a href="<%= Routes.live_path(@conn, BattleBoxWeb.Bots, @bot.user.github_login_name) %>">Bots</a>
+      / <%= @bot.name %>
+    </div>
+  </div>
 </div>

--- a/lib/battle_box_web/views/api_key_view.ex
+++ b/lib/battle_box_web/views/api_key_view.ex
@@ -1,0 +1,3 @@
+defmodule BattleBoxWeb.ApiKeyView do
+  use BattleBoxWeb, :view
+end

--- a/priv/repo/migrations/20200213223253_create_bots.exs
+++ b/priv/repo/migrations/20200213223253_create_bots.exs
@@ -5,11 +5,10 @@ defmodule BattleBox.Repo.Migrations.CreateBots do
     create table("bots") do
       add :name, :text, null: false
       add :user_id, :uuid, null: false
-      add :token, :text, null: false
       timestamps()
     end
 
     create index("bots", [:name], unique: true)
-    create index("bots", [:token], unique: true)
+    create index("bots", [:user_id])
   end
 end

--- a/priv/repo/migrations/20200519041125_create_api_keys.exs
+++ b/priv/repo/migrations/20200519041125_create_api_keys.exs
@@ -1,0 +1,16 @@
+defmodule BattleBox.Repo.Migrations.CreateApiKeys do
+  use Ecto.Migration
+
+  def change do
+    create table("api_keys") do
+      add :name, :text, null: false
+      add :hashed_token, :bytea, null: false
+      add :user_id, :uuid, null: false
+      add :last_used, :timestamp, null: false
+      timestamps()
+    end
+
+    create index("api_keys", [:hashed_token], unique: true)
+    create index("api_keys", [:user_id])
+  end
+end

--- a/priv/repo/migrations/20200519041125_create_api_keys.exs
+++ b/priv/repo/migrations/20200519041125_create_api_keys.exs
@@ -6,7 +6,7 @@ defmodule BattleBox.Repo.Migrations.CreateApiKeys do
       add :name, :text, null: false
       add :hashed_token, :bytea, null: false
       add :user_id, :uuid, null: false
-      add :last_used, :timestamp, null: false
+      add :last_used, :timestamp
       timestamps()
     end
 

--- a/test/battle_box/api_keys/api_key_test.exs
+++ b/test/battle_box/api_keys/api_key_test.exs
@@ -9,8 +9,8 @@ defmodule BattleBox.ApiKeyTest do
                          |> NaiveDateTime.truncate(:second)
 
   describe "validations" do
-    test "Name must be greater than 3" do
-      changeset = ApiKey.changeset(%ApiKey{}, %{name: "AA"})
+    test "Name must be greater than 1" do
+      changeset = ApiKey.changeset(%ApiKey{}, %{name: ""})
       refute changeset.valid?
     end
 
@@ -31,8 +31,8 @@ defmodule BattleBox.ApiKeyTest do
       %{key: key}
     end
 
-    test "it generates a token, a hashed token, and marks the last used value", %{key: key} do
-      assert %NaiveDateTime{} = key.last_used
+    test "it generates a token, a hashed token, and no last used value", %{key: key} do
+      assert key.last_used == nil
       assert byte_size(key.hashed_token) == 32
       assert byte_size(key.token) == 26
       assert :crypto.hash(:sha256, key.token) == key.hashed_token

--- a/test/battle_box/api_keys/api_key_test.exs
+++ b/test/battle_box/api_keys/api_key_test.exs
@@ -1,0 +1,58 @@
+defmodule BattleBox.ApiKeyTest do
+  use BattleBox.DataCase
+  alias BattleBox.{ApiKey, Repo}
+  import Ecto.Changeset
+
+  @user_id Ecto.UUID.generate()
+  @some_time_in_the_past NaiveDateTime.utc_now()
+                         |> NaiveDateTime.add(-1_000_000_000)
+                         |> NaiveDateTime.truncate(:second)
+
+  describe "validations" do
+    test "Name must be greater than 3" do
+      changeset = ApiKey.changeset(%ApiKey{}, %{name: "AA"})
+      refute changeset.valid?
+    end
+
+    test "Name may not be longer than 30" do
+      name = :crypto.strong_rand_bytes(16) |> Base.encode16()
+      assert String.length(name) > 30
+      changeset = ApiKey.changeset(%ApiKey{}, %{name: name})
+      refute changeset.valid?
+    end
+  end
+
+  describe "Token Manipulation" do
+    setup do
+      {:ok, key} =
+        ApiKey.changeset(%ApiKey{user_id: @user_id}, %{name: "TEST"})
+        |> Repo.insert()
+
+      %{key: key}
+    end
+
+    test "it generates a token, a hashed token, and marks the last used value", %{key: key} do
+      assert %NaiveDateTime{} = key.last_used
+      assert byte_size(key.hashed_token) == 32
+      assert byte_size(key.token) == 26
+      assert :crypto.hash(:sha256, key.token) == key.hashed_token
+    end
+
+    test "you can get a token by its hash (and only its hash)", %{key: key} do
+      from_token = ApiKey.from_token(key.token)
+      assert key.id == from_token.id
+      assert nil == ApiKey.from_token("some random number")
+    end
+
+    test "you can mark the updated time", %{key: key} do
+      {:ok, key} =
+        change(key, last_used: @some_time_in_the_past)
+        |> Repo.update()
+
+      assert key.last_used == @some_time_in_the_past
+      {:ok, key} = ApiKey.mark_used!(key)
+      assert key.last_used != @some_time_in_the_past
+      assert NaiveDateTime.diff(NaiveDateTime.utc_now(), key.last_used) < 2
+    end
+  end
+end

--- a/test/battle_box/bots/bot_test.exs
+++ b/test/battle_box/bots/bot_test.exs
@@ -1,30 +1,19 @@
 defmodule BattleBox.BotTest do
   use BattleBox.DataCase
-  alias BattleBox.{Bot, User, Repo}
+  alias BattleBox.{Bot, Repo}
 
   @user_id Ecto.UUID.generate()
 
-  test "bots auto generate tokens" do
-    assert {:ok, bot} =
-             Bot.changeset(%Bot{}, %{
-               name: "Test Name",
-               user_id: @user_id
-             })
-             |> Repo.insert()
-
-    assert <<_::256>> = bot.token
-  end
-
   describe "validations" do
-    test "Name must be greater than 3" do
-      changeset = Bot.changeset(%Bot{}, %{name: "AA", user_id: @user_id})
+    test "Name must be greater than 1" do
+      changeset = Bot.changeset(%Bot{}, %{name: ""})
       refute changeset.valid?
     end
 
     test "Name may not be longer than 20" do
       name = :crypto.strong_rand_bytes(11) |> Base.encode16()
       assert String.length(name) > 20
-      changeset = Bot.changeset(%Bot{}, %{name: name, user_id: @user_id})
+      changeset = Bot.changeset(%Bot{}, %{name: name})
       refute changeset.valid?
     end
   end
@@ -34,49 +23,17 @@ defmodule BattleBox.BotTest do
       {:ok, user} = create_user(id: @user_id)
 
       {:ok, bot} =
-        Bot.changeset(%Bot{}, %{
-          name: "Test Name",
-          user_id: @user_id
-        })
+        user
+        |> Ecto.build_assoc(:bots)
+        |> Bot.changeset(%{name: "Test Name"})
         |> Repo.insert()
 
       %{user: user, bot: bot}
     end
 
-    test "you can get a bot by id", %{bot: %{id: id}} do
-      assert nil == Bot.get_by_id(Ecto.UUID.generate())
-      assert %Bot{id: ^id} = Bot.get_by_id(id)
-    end
-
-    test "you can get a bot by token", %{bot: %{id: id, token: token}} do
-      assert nil == Bot.get_by_token("INVALID TOKEN")
-      assert %Bot{id: ^id} = Bot.get_by_token(token)
-    end
-
-    test "you can preload the user", %{bot: %{id: id}, user: %{id: user_id}} do
-      assert %Bot{id: ^id, user: %{id: ^user_id}} =
-               Bot.get_by_id(id)
-               |> Repo.preload(:user)
-    end
-
-    test "you can use the by identifier", %{bot: %{id: id} = bot} do
-      assert nil == Bot.get_by_identifier(nil)
-      assert %{id: ^id} = Bot.get_by_identifier(id)
-      assert %{id: ^id} = Bot.get_by_identifier(bot.name)
-    end
-  end
-
-  describe "banned?" do
-    test "a bot without a user is not banned" do
-      refute Bot.banned?(%Bot{})
-    end
-
-    test "A bot with a user who isn't banned isn't banned" do
-      refute Bot.banned?(%Bot{user: %User{is_banned: false, id: @user_id}, user_id: @user_id})
-    end
-
-    test "A bot with a user who is banned is banned" do
-      assert Bot.banned?(%Bot{user: %User{is_banned: true, id: @user_id}, user_id: @user_id})
+    test "you can get by name", %{bot: %{id: id, name: name}} do
+      assert nil == Bot.get_by_name("NOT A REAL NAME")
+      assert %{id: ^id} = Bot.get_by_name(name)
     end
   end
 end

--- a/test/battle_box/game_engine/bot_server/bot_server_test.exs
+++ b/test/battle_box/game_engine/bot_server/bot_server_test.exs
@@ -14,11 +14,13 @@ defmodule BattleBox.GameEngine.BotServerTest do
   end
 
   setup do
+    {:ok, user} = create_user(id: @user_id)
+
     {:ok, bot} =
-      Bot.create(%{
-        user_id: @user_id,
-        name: "BOT_NAME"
-      })
+      user
+      |> Ecto.build_assoc(:bots)
+      |> Bot.changeset(%{name: "TEST BOT"})
+      |> Repo.insert()
 
     {:ok, lobby} =
       Lobby.create(%{

--- a/test/battle_box/game_engine/match_maker/match_maker_logic_test.exs
+++ b/test/battle_box/game_engine/match_maker/match_maker_logic_test.exs
@@ -5,11 +5,13 @@ defmodule BattleBox.GameEngine.MatchMaker.MatchMakerLogicTest do
   import BattleBox.TestConvenienceHelpers, only: [named_proxy: 1]
 
   setup do
+    {:ok, user} = create_user()
+
     {:ok, bot} =
-      Bot.create(%{
-        name: "FOO",
-        user_id: Ecto.UUID.generate()
-      })
+      user
+      |> Ecto.build_assoc(:bots)
+      |> Bot.changeset(%{name: "TEST BOT"})
+      |> Repo.insert()
 
     {:ok, lobby} =
       Lobby.create(%{

--- a/test/battle_box/game_engine/match_maker/match_maker_server_test.exs
+++ b/test/battle_box/game_engine/match_maker/match_maker_server_test.exs
@@ -18,11 +18,13 @@ defmodule BattleBox.GameEngine.MatchMakerServerTest do
   end
 
   setup do
+    {:ok, user} = create_user()
+
     {:ok, bot} =
-      Bot.create(%{
-        user_id: Ecto.UUID.generate(),
-        name: "FOO"
-      })
+      user
+      |> Ecto.build_assoc(:bots)
+      |> Bot.changeset(%{name: "FOO"})
+      |> Repo.insert()
 
     {:ok, lobby} =
       Lobby.create(%{

--- a/test/battle_box/game_engine/match_maker/match_maker_test.exs
+++ b/test/battle_box/game_engine/match_maker/match_maker_test.exs
@@ -10,11 +10,13 @@ defmodule BattleBox.GameEngine.MatchMakerTest do
   end
 
   setup do
+    {:ok, user} = create_user(id: @user_id)
+
     {:ok, bot} =
-      Bot.create(%{
-        name: "FOO",
-        user_id: @user_id
-      })
+      user
+      |> Ecto.build_assoc(:bots)
+      |> Bot.changeset(%{name: "FOO"})
+      |> Repo.insert()
 
     %{bot: bot}
   end

--- a/test/battle_box_web/controllers/bot_controller_test.exs
+++ b/test/battle_box_web/controllers/bot_controller_test.exs
@@ -38,11 +38,17 @@ defmodule BattleBoxWeb.BotControllerTest do
       |> post("/bots", %{"bot" => %{"name" => "FOO"}})
 
     assert "/bots/" <> id = redirected_to(conn, 302)
-    assert %Bot{user_id: @user_id} = Bot.get_by_id(id)
+    assert %Bot{user_id: @user_id} = Repo.get(Bot, id)
   end
 
   test "trying to create a bot with a name that exists is an error", %{conn: conn} do
-    Bot.changeset(%Bot{}, %{name: "FOO", user_id: @user_id}) |> Repo.insert!()
+    {:ok, user} = create_user(id: @user_id)
+
+    {:ok, bot} =
+      user
+      |> Ecto.build_assoc(:bots)
+      |> Bot.changeset(%{name: "TEST BOT"})
+      |> Repo.insert()
 
     conn =
       conn

--- a/test/battle_box_web/live/bot_server_follow_test.exs
+++ b/test/battle_box_web/live/bot_server_follow_test.exs
@@ -24,10 +24,10 @@ defmodule BattleBoxWeb.BotsServerFollowTest do
       })
 
     {:ok, bot} =
-      Bot.create(%{
-        user_id: @user_id,
-        name: "TEST BOT"
-      })
+      user
+      |> Ecto.build_assoc(:bots)
+      |> Bot.changeset(%{name: "TEST BOT"})
+      |> Repo.insert()
 
     {:ok, bot_server, _} =
       GameEngine.start_bot(context.game_engine, %{

--- a/test/battle_box_web/live/bots_test.exs
+++ b/test/battle_box_web/live/bots_test.exs
@@ -23,10 +23,10 @@ defmodule BattleBoxWeb.BotsTest do
       })
 
     {:ok, bot} =
-      Bot.create(%{
-        user_id: @user_id,
-        name: "TEST BOT"
-      })
+      user
+      |> Ecto.build_assoc(:bots)
+      |> Bot.changeset(%{name: "TEST BOT"})
+      |> Repo.insert()
 
     %{bot: bot, user: user, lobby: lobby}
   end

--- a/test/battle_box_web/live/game_test.exs
+++ b/test/battle_box_web/live/game_test.exs
@@ -21,7 +21,13 @@ defmodule BattleBoxWeb.GameTest do
   setup do
     {:ok, user} = create_user(%{user_id: @user_id})
     {:ok, lobby} = Lobby.create(%{name: "TEST LOBBY", game_type: RobotGame, user_id: @user_id})
-    {:ok, bot} = Bot.create(%{user: user, user_id: @user_id, name: "FOO"})
+
+    {:ok, bot} =
+      user
+      |> Ecto.build_assoc(:bots)
+      |> Bot.changeset(%{name: "FOO"})
+      |> Repo.insert()
+
     bot = Repo.preload(bot, :user)
 
     %{

--- a/test/battle_box_web/live/lobby_test.exs
+++ b/test/battle_box_web/live/lobby_test.exs
@@ -19,7 +19,12 @@ defmodule BattleBoxWeb.LobbyTest do
   setup context do
     {:ok, user} = create_user(user_id: @user_id)
     {:ok, lobby} = Lobby.create(%{name: "TEST LOBBY", game_type: "robot_game", user_id: @user_id})
-    {:ok, bot} = Bot.create(%{user_id: @user_id, name: "TEST BOT"})
+
+    {:ok, bot} =
+      user
+      |> Ecto.build_assoc(:bots)
+      |> Bot.changeset(%{name: "TEST BOT"})
+      |> Repo.insert()
 
     {:ok, bot_server_1, _} =
       GameEngine.start_bot(context.game_engine, %{

--- a/test/support/data_helpers.ex
+++ b/test/support/data_helpers.ex
@@ -3,7 +3,17 @@ defmodule BattleBox.Test.DataHelpers do
   import Phoenix.ConnTest
 
   def signin(conn, opts \\ %{}) do
-    {:ok, user} = create_user(opts)
+    opts = Enum.into(opts, %{})
+
+    user =
+      case opts do
+        %{user: user} ->
+          user
+
+        %{} ->
+          {:ok, user} = create_user(opts)
+          user
+      end
 
     conn
     |> init_test_session(token: "foo")


### PR DESCRIPTION
# Why?

Its nicer if you can manage one token for all your bots. You can also rotate tokens gracefully. This opens the door to reuse api keys for http api access or attaching debuggers or whatever.

## Some nice features
- Tokens are stored in hashed form, so having the db leaked wouldn't reveal all the tokens
- `last_used` is accounted for on the token

![image](https://user-images.githubusercontent.com/16196910/82398704-78d45100-9a21-11ea-9c40-44e4280ee07e.png)

![image](https://user-images.githubusercontent.com/16196910/82400052-66a7e200-9a24-11ea-8402-33377032bf34.png)

![image](https://user-images.githubusercontent.com/16196910/82400020-5a238980-9a24-11ea-8009-441f9c5e09cd.png)

![image](https://user-images.githubusercontent.com/16196910/82402451-61e62c80-9a2a-11ea-992f-6b648f55f478.png)


```
battle_box_dev=# \d api_keys
                            Table "public.api_keys"
    Column    |              Type              | Collation | Nullable | Default
--------------+--------------------------------+-----------+----------+---------
 id           | uuid                           |           | not null |
 name         | text                           |           | not null |
 hashed_token | bytea                          |           | not null |
 user_id      | uuid                           |           | not null |
 last_used    | timestamp without time zone    |           |              |
 inserted_at  | timestamp(0) without time zone |           | not null |
 updated_at   | timestamp(0) without time zone |           | not null |
Indexes:
    "api_keys_pkey" PRIMARY KEY, btree (id)
    "api_keys_hashed_token_index" UNIQUE, btree (hashed_token)
    "api_keys_user_id_index" btree (user_id)
```